### PR TITLE
Update ignored-packages

### DIFF
--- a/repology/ignored-packages
+++ b/repology/ignored-packages
@@ -92,6 +92,7 @@ games-action/supermariowar
 #
 
 media-fonts/fonts-meta
+media-gfx/alembic-1.9.0
 media-gfx/fdm-materials::dports
 media-sound/pulseeffects
 


### PR DESCRIPTION
ignored-packages: add v1.9.0 for media-gfx/alembic

The v1.9.0 at repology refers to the dev-python/alembic package.

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>